### PR TITLE
Fix "Error: Implicit conversion from BE to number" in big crunch autobuyer

### DIFF
--- a/src/core/autobuyers/big-crunch-autobuyer.js
+++ b/src/core/autobuyers/big-crunch-autobuyer.js
@@ -104,7 +104,7 @@ export class BigCrunchAutobuyerState extends UpgradeableAutobuyerState {
   }
 
   get timeToNextTick() {
-    return Math.clampMin(this.time - Time.thisInfinityRealTime.totalSeconds, 0);
+    return Math.clampMin(this.time - Time.thisInfinityRealTime.totalSeconds.toNumberMax(Number.MAX_VALUE), 0);
   }
 
   get willInfinity() {
@@ -114,7 +114,7 @@ export class BigCrunchAutobuyerState extends UpgradeableAutobuyerState {
       case AUTO_CRUNCH_MODE.AMOUNT:
         return gainedInfinityPoints().gte(this.amount);
       case AUTO_CRUNCH_MODE.TIME:
-        return Time.thisInfinityRealTime.totalSeconds > this.time;
+        return Time.thisInfinityRealTime.totalSeconds.toNumberMax(Number.MAX_VALUE) > this.time;
       case AUTO_CRUNCH_MODE.X_HIGHEST:
       default:
         return gainedInfinityPoints().gte(this.highestPrevPrestige.times(this.xHighest));


### PR DESCRIPTION
Fix "Error: Implicit conversion from BE to number" in big crunch autobuyer.

https://github.com/aquamarine309/ADPuzzleTestVer/issues/3